### PR TITLE
Changes to Docker file to allow build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ USER nonroot
 # Install gems
 RUN bundle install
 
+# switch back to root for the rest of the show
+USER root
+
 # Add the source dir
 ADD . /toshi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,26 @@
-# Start with an Ubuntu 14.04 image that has ruby 2.1.2
-FROM litaio/ruby:2.1.2
+# Start with an Ubuntu 14.04 image that has ruby 2.1.5
+FROM litaio/ruby:2.1.5
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Install dependencies
-RUN apt-get -y install libpq-dev
+RUN apt-get -q -y install libpq-dev git
 RUN gem install bundler
 
-# Add the Gemfile to the image
-# Separate this from the source so as not to bust the cache
 ADD Gemfile /Gemfile
 ADD Gemfile.lock /Gemfile.lock
 
+# Create a nonroot user and switch to it so that we can run bundle install
+RUN /usr/sbin/useradd --create-home --home-dir /usr/local/nonroot --shell /bin/bash nonroot
+RUN /usr/sbin/adduser nonroot sudo
+RUN chown -R nonroot /usr/local/
+RUN chown -R nonroot /usr/lib/
+RUN chown -R nonroot /usr/bin/
+
+USER nonroot
+
 # Install gems
-RUN bundle install 
+RUN bundle install
 
 # Add the source dir
 ADD . /toshi
@@ -23,4 +32,4 @@ ADD config/toshi.yml.example /toshi/config/toshi.yml
 WORKDIR /toshi
 
 # Expose port 5000 of the container to the host
-EXPOSE 5000
+EXPOSE 5000 


### PR DESCRIPTION
Running 
`sudo docker build -t=coinbase/node .`
produces several errors
To begin with, there is no more litaio/ruby:2.1.2
But even after we change that to litaio/ruby or litaio/ruby:2.1.5
we still get a bunch of errors:

**[toshi (master)]$ sudo docker build -t=coinbase/toshi .**
Sending build context to Docker daemon 13.04 MB
Sending build context to Docker daemon 
Step 0 : FROM litaio/ruby:2.1.5
 ---> fd67907704a4
Step 1 : RUN apt-get -y install libpq-dev
 ---> Running in f9fce57f1968
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  comerr-dev krb5-multidev libgssrpc4 libkadm5clnt-mit8 libkadm5srv-mit8
  libkdb5-6 libkrb5-dev libpq5
Suggested packages:
  doc-base krb5-doc krb5-user postgresql-doc-9.1
The following NEW packages will be installed:
  comerr-dev krb5-multidev libgssrpc4 libkadm5clnt-mit8 libkadm5srv-mit8
  libkdb5-6 libkrb5-dev libpq-dev libpq5
0 upgraded, 9 newly installed, 0 to remove and 0 not upgraded.
Need to get 875 kB of archives.
After this operation, 3473 kB of additional disk space will be used.
Get:1 http://http.debian.net/debian/ wheezy/main libgssrpc4 amd64 1.10.1+dfsg-5+deb7u2 [87.7 kB]
Get:2 http://http.debian.net/debian/ wheezy/main libkadm5clnt-mit8 amd64 1.10.1+dfsg-5+deb7u2 [68.0 kB]
Get:3 http://http.debian.net/debian/ wheezy/main libkdb5-6 amd64 1.10.1+dfsg-5+deb7u2 [67.1 kB]
Get:4 http://http.debian.net/debian/ wheezy/main libkadm5srv-mit8 amd64 1.10.1+dfsg-5+deb7u2 [84.9 kB]
Get:5 http://http.debian.net/debian/ wheezy/main comerr-dev amd64 2.1-1.42.5-1.1 [43.8 kB]
Get:6 http://http.debian.net/debian/ wheezy/main krb5-multidev amd64 1.10.1+dfsg-5+deb7u2 [153 kB]
Get:7 http://http.debian.net/debian/ wheezy/main libpq5 amd64 9.1.14-0+deb7u1 [137 kB]
Get:8 http://http.debian.net/debian/ wheezy/main libkrb5-dev amd64 1.10.1+dfsg-5+deb7u2 [39.7 kB]
Get:9 http://http.debian.net/debian/ wheezy/main libpq-dev amd64 9.1.14-0+deb7u1 [193 kB]
**debconf: delaying package configuration, since apt-utils is not installed**
Fetched 875 kB in 10s (79.9 kB/s)
Selecting previously unselected package libgssrpc4:amd64.
(Reading database ... 11383 files and directories currently installed.)
Unpacking libgssrpc4:amd64 (from .../libgssrpc4_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libkadm5clnt-mit8:amd64.
Unpacking libkadm5clnt-mit8:amd64 (from .../libkadm5clnt-mit8_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libkdb5-6:amd64.
Unpacking libkdb5-6:amd64 (from .../libkdb5-6_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libkadm5srv-mit8:amd64.
Unpacking libkadm5srv-mit8:amd64 (from .../libkadm5srv-mit8_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package comerr-dev.
Unpacking comerr-dev (from .../comerr-dev_2.1-1.42.5-1.1_amd64.deb) ...
Selecting previously unselected package krb5-multidev.
Unpacking krb5-multidev (from .../krb5-multidev_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libpq5.
Unpacking libpq5 (from .../libpq5_9.1.14-0+deb7u1_amd64.deb) ...
Selecting previously unselected package libkrb5-dev.
Unpacking libkrb5-dev (from .../libkrb5-dev_1.10.1+dfsg-5+deb7u2_amd64.deb) ...
Selecting previously unselected package libpq-dev.
Unpacking libpq-dev (from .../libpq-dev_9.1.14-0+deb7u1_amd64.deb) ...
Setting up libgssrpc4:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libkadm5clnt-mit8:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libkdb5-6:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up libkadm5srv-mit8:amd64 (1.10.1+dfsg-5+deb7u2) ...
Setting up comerr-dev (2.1-1.42.5-1.1) ...
Setting up krb5-multidev (1.10.1+dfsg-5+deb7u2) ...
Setting up libpq5 (9.1.14-0+deb7u1) ...
Setting up libkrb5-dev (1.10.1+dfsg-5+deb7u2) ...
Setting up libpq-dev (9.1.14-0+deb7u1) ...
 ---> f4313c771a36
Removing intermediate container f9fce57f1968
Step 2 : RUN gem install bundler
 ---> Running in e8afb2b31b1d
Successfully installed bundler-1.7.6
1 gem installed
 ---> 27ef0e4dca76
Removing intermediate container e8afb2b31b1d
Step 3 : ADD Gemfile /Gemfile
 ---> d9c10de05e7c
Removing intermediate container 4de115bf31aa
Step 4 : ADD Gemfile.lock /Gemfile.lock
 ---> 4719f33bea68
Removing intermediate container 39b57416f6b8
Step 5 : **RUN bundle install**
 ---> Running in df8bc606105e
**Don't run Bundler as root. Bundler can ask for sudo if it is needed, and**
**installing your bundle as root will break this application for all non-root**
**users on this machine.**
**Fetching gem metadata from https://rubygems.org/.......**
**You need to install git to be able to use gems from git repositories. For help**
**installing git, please refer to GitHub's tutorial at**
**https://help.github.com/articles/set-up-git**
2014/11/19 14:04:01 The command [/bin/sh -c bundle install] **returned a non-zero code: 11**
[toshi (master)]$ 

so bottom line, the build was not successful.
In order to fix that I did the following three things:

*  litaio/ruby:2.1.2 --> litaio/ruby:2.1.5
* Added git as a dependency
* Created and switched to a nonroot user before running bundle install

Now docker build runs ok.