### PR TITLE
Do not insert randomly generated private key pair

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,4 +32,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.functional_vboxsf     = false
   end
 
+  config.ssh.insert_key = false
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@ VAGRANTFILE_API_VERSION = "2"
 COREOS_UPDATE_CHANNEL = "alpha"
 VB_MEMORY = 1024
 VB_CPUS = 1
+PRIVATE_KEY_PATH = ENV['TOSHI_VAGRANT_PRIVATE_KEY_PATH']
+PASSWORD = ENV['TOSHI_VAGRANT_PASSWORD']
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -32,6 +34,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.functional_vboxsf     = false
   end
 
-  config.ssh.insert_key = false
+  if PRIVATE_KEY_PATH
+    config.ssh.private_key_path = PRIVATE_KEY_PATH
+  elsif PASSWORD
+    config.ssh.password = PASSWORD
+  else
+    config.ssh.insert_key = false
+  end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,6 @@ VAGRANTFILE_API_VERSION = "2"
 COREOS_UPDATE_CHANNEL = "alpha"
 VB_MEMORY = 1024
 VB_CPUS = 1
-PRIVATE_KEY_PATH = ENV['TOSHI_VAGRANT_PRIVATE_KEY_PATH']
-PASSWORD = ENV['TOSHI_VAGRANT_PASSWORD']
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -34,12 +32,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.functional_vboxsf     = false
   end
 
-  if PRIVATE_KEY_PATH
-    config.ssh.private_key_path = PRIVATE_KEY_PATH
-  elsif PASSWORD
-    config.ssh.password = PASSWORD
-  else
-    config.ssh.insert_key = false
-  end
+  config.ssh.insert_key = false
 
 end


### PR DESCRIPTION
Vagrant recently([2014/12/9](https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md))  [required] (https://github.com/mitchellh/vagrant/pull/4707) that you set ```config.ssh.password```, or ```config.ssh.private_key_path``` for authenticating into the machine. If you don't it randomly generates an SSH key pair for you. After that, if you halt the machine, you don't have the key to get back in when it starts up.

PR allows the user to to set ```config.ssh.private_key_path``` or ```config.ssh.password``` with environment variables. If neither one is set, it falls back to the key in ```~/.vagrant.d/insecure_private_key```.