### PR TITLE
Update eventmachine for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "2.0.0"
   - "2.1.1"
   - "2.1.2"
+  - "2.2.0"
 services:
   - redis-server
 env: DATABASE_URL=postgres://postgres@127.0.0.1:5432/toshi_test REDIS_URL=redis://127.0.0.1:6379/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
-    eventmachine (1.0.3)
+    eventmachine (1.0.7)
     faye-websocket (0.7.4)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,9 +25,9 @@ GEM
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
     eventmachine (1.0.7)
-    faye-websocket (0.7.4)
+    faye-websocket (0.9.2)
       eventmachine (>= 0.12.0)
-      websocket-driver (>= 0.3.1)
+      websocket-driver (>= 0.5.1)
     ffi (1.9.3)
     ffi-compiler (0.1.3)
       ffi (>= 1.0.0)
@@ -93,7 +93,9 @@ GEM
     thor (0.19.1)
     tilt (1.4.1)
     timers (1.1.0)
-    websocket-driver (0.3.4)
+    websocket-driver (0.5.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Fixes https://github.com/coinbase/toshi/issues/160 and makes Toshi Ruby 2.2.0 compatible.