### PR TITLE
task to remove unconfirmed records from DB

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -96,3 +96,9 @@ task :cache_totals do
     Toshi.db.run(query)
   end
 end
+
+task :remove_unconfirmed_records do
+  Toshi.db = Sequel.connect(Toshi.settings[:database_url])
+
+  Toshi::Models::UnconfirmedTransaction.remove_all
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -2,3 +2,12 @@ def fixtures_file(relative_path)
   dir = Dir["./spec/fixtures"]
   File.read File.join(dir, relative_path)
 end
+
+def fake_hash
+  SecureRandom.hex(16)
+end
+
+def testnet_address(pubkey = SecureRandom.hex(20))
+  pubkey = Bitcoin.hash160(pubkey)
+  Bitcoin.hash160_to_address pubkey
+end

--- a/spec/toshi/models/unconfirmed_transaction_spec.rb
+++ b/spec/toshi/models/unconfirmed_transaction_spec.rb
@@ -15,6 +15,13 @@ module Toshi::Models
         outputs = [output]
         addresses = [[address.address]]
         UnconfirmedTransaction.upsert_output_addresses(tx.id, outputs, outputs.map(&:id), addresses)
+
+        blockchain = Blockchain.new
+        processor = Toshi::Processor.new
+        blockchain.load_from_json("simple_chain_1.json")
+        blockchain.chain['main'].each{|height, block|
+          processor.process_block(block, raise_errors=true)
+        }
       end
 
       it { is_expected.to change { Toshi.db[:unconfirmed_addresses_outputs].count }.by(-1) }
@@ -23,6 +30,14 @@ module Toshi::Models
       it { is_expected.to change { UnconfirmedInput.count }.by(-1) }
       it { is_expected.to change { UnconfirmedTransaction.count }.by(-1) }
       it { is_expected.to change { UnconfirmedRawTransaction.count }.by(-1) }
+
+      it { is_expected.not_to change { Output.count } }
+      it { is_expected.not_to change { Input.count } }
+      it { is_expected.not_to change { Address.count } }
+      it { is_expected.not_to change { Transaction.count } }
+      it { is_expected.not_to change { RawTransaction.count } }
+      it { is_expected.not_to change { Block.count } }
+      it { is_expected.not_to change { RawBlock.count } }
     end
   end
 end

--- a/spec/toshi/models/unconfirmed_transaction_spec.rb
+++ b/spec/toshi/models/unconfirmed_transaction_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+module Toshi::Models
+  describe UnconfirmedTransaction do
+    describe '.remove_all' do
+      subject { lambda { UnconfirmedTransaction.remove_all } }
+
+      before do
+        raw_tx = UnconfirmedRawTransaction.create(hsh: fake_hash)
+        tx = UnconfirmedTransaction.create(hsh: raw_tx.hsh)
+        address = UnconfirmedAddress.create(address: testnet_address)
+        output = UnconfirmedOutput.create(hsh: fake_hash, amount: 1e8, script: 'script')
+        UnconfirmedInput.create(hsh: fake_hash, index: 0, prev_out: output.hsh)
+
+        outputs = [output]
+        addresses = [[address.address]]
+        UnconfirmedTransaction.upsert_output_addresses(tx.id, outputs, outputs.map(&:id), addresses)
+      end
+
+      it { is_expected.to change { Toshi.db[:unconfirmed_addresses_outputs].count }.by(-1) }
+      it { is_expected.to change { UnconfirmedAddress.count }.by(-1) }
+      it { is_expected.to change { UnconfirmedOutput.count }.by(-1) }
+      it { is_expected.to change { UnconfirmedInput.count }.by(-1) }
+      it { is_expected.to change { UnconfirmedTransaction.count }.by(-1) }
+      it { is_expected.to change { UnconfirmedRawTransaction.count }.by(-1) }
+    end
+  end
+end


### PR DESCRIPTION
Rake task to easily remove unconfirmed records from the database, for before taking a snapshot.

Mostly just writing tests around UnconfirmedTransaction.remove_all.