### PR TITLE
Add hack from Bitcoin Core to deal with long side branches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'foreman'
-gem 'bitcoin-ruby', github: 'lian/bitcoin-ruby', require: 'bitcoin', ref: 'ddfb82148914247aaeec7cd4e9cd63d8f3eb129d'
+gem 'bitcoin-ruby', github: 'lian/bitcoin-ruby', require: 'bitcoin', ref: '69123208d45a19da446c5e0079d4fa2e225e5be6'
 gem 'ffi'
 gem 'eventmachine'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/lian/bitcoin-ruby.git
-  revision: ddfb82148914247aaeec7cd4e9cd63d8f3eb129d
-  ref: ddfb82148914247aaeec7cd4e9cd63d8f3eb129d
+  revision: 69123208d45a19da446c5e0079d4fa2e225e5be6
+  ref: 69123208d45a19da446c5e0079d4fa2e225e5be6
   specs:
     bitcoin-ruby (0.0.6)
 


### PR DESCRIPTION
Toshi was missing the equivalent of this fun little nugget: https://github.com/bitcoin/bitcoin/blob/0.8/src/main.cpp#L3423-L3427

Note: Ideally I don't merge this until the required bitcoin-ruby change is merged such that toshi isn't relying on my fork.