### PR TITLE
New API to filter tx inputs and outputs for result size reduction and speed increase.

### DIFF
--- a/lib/toshi/models/address.rb
+++ b/lib/toshi/models/address.rb
@@ -71,11 +71,18 @@ module Toshi
           hash[:unconfirmed_balance] = unconfirmed_address ? unconfirmed_address.balance(address) : 0
 
           if options[:show_txs]
-            if unconfirmed_address
-              hash[:unconfirmed_transactions] = UnconfirmedTransaction.to_hash_collection(unconfirmed_address.transactions)
+            
+            tx_options = {}
+            
+            if options[:filter_tx]
+              tx_options[:filter_tx_address] = address.address
             end
-
-            hash[:transactions] = Transaction.to_hash_collection(address.transactions(options[:offset], options[:limit]))
+            
+            if unconfirmed_address
+              hash[:unconfirmed_transactions] = UnconfirmedTransaction.to_hash_collection(unconfirmed_address.transactions, tx_options)
+            end
+            
+            hash[:transactions] = Transaction.to_hash_collection(address.transactions(options[:offset], options[:limit]), tx_options)
           end
 
           collection << hash

--- a/lib/toshi/models/unconfirmed_transaction.rb
+++ b/lib/toshi/models/unconfirmed_transaction.rb
@@ -347,11 +347,11 @@ module Toshi
         Toshi.db[:unconfirmed_ledger_entries].multi_insert(entries)
       end
 
-      def to_hash
-        self.class.to_hash_collection([self]).first
+      def to_hash(options = {})
+        self.class.to_hash_collection([self], options).first
       end
 
-      def self.to_hash_collection(transactions)
+      def self.to_hash_collection(transactions, options = {})
         return [] unless transactions.any?
         transaction_ids = transactions.map{|transaction| transaction.id }
 

--- a/lib/toshi/web/api.rb
+++ b/lib/toshi/web/api.rb
@@ -161,6 +161,19 @@ module Toshi
         end
       end
 
+      get '/addresses/:address/transactionsfiltered.?:format?' do
+        address = Toshi::Models::Address.where(address: params[:address]).first
+        address = Toshi::Models::UnconfirmedAddress.where(address: params[:address]).first unless address
+        raise NotFoundError unless address
+
+        case format
+        when 'json'
+          json address.to_hash(options={show_txs: true, filter_tx: true, offset: params[:offset], limit: params[:limit]})
+        else
+          raise InvalidFormatError
+        end
+      end
+
       get '/addresses/:address/transactions.?:format?' do
         address = Toshi::Models::Address.where(address: params[:address]).first
         address = Toshi::Models::UnconfirmedAddress.where(address: params[:address]).first unless address

--- a/spec/toshi/api_spec.rb
+++ b/spec/toshi/api_spec.rb
@@ -183,6 +183,40 @@ describe Toshi::Web::Api, :type => :request do
     end
   end
 
+  describe "GET /addresses/<hash>/transactionsfiltered" do
+    it "loads address & transactions" do
+      get '/addresses/mw851HctCPZUuRCC4KktwKCJQqBz9Xwohz/transactionsfiltered'
+
+      expect(last_response).to be_ok
+      expect(json['hash']).to eq('mw851HctCPZUuRCC4KktwKCJQqBz9Xwohz')
+      expect(json['balance']).to eq(5000000000)
+      expect(json['received']).to eq(5000000000)
+      expect(json['sent']).to eq(0)
+      expect(json['unconfirmed_received']).to eq(0)
+      expect(json['unconfirmed_sent']).to eq(0)
+      expect(json['unconfirmed_balance']).to eq(0)
+
+      expect(json['transactions'][0]['hash']).to eq('40d17ca54556e99e1dec77324f99da327c7c6fde243ab069dec1d5b5352fc768')
+      expect(json['transactions'][0]['version']).to eq(1)
+      expect(json['transactions'][0]['lock_time']).to eq(0)
+      expect(json['transactions'][0]['size']).to eq(169)
+      expect(json['transactions'][0]['inputs'].count).to eq(0)
+      expect(json['transactions'][0]['outputs'][0]['amount']).to eq(5000000000)
+      expect(json['transactions'][0]['outputs'][0]['spent']).to eq(false)
+      expect(json['transactions'][0]['outputs'][0]['script']).to eq('04a30984dcecc38d8bb47ed1362787416bf0c39ec1afb07847d72e576f3776f3aa80570d6483c2fa09dc8b6161efd03125755752318838d2635932b1c2c43e9a14 OP_CHECKSIG')
+      expect(json['transactions'][0]['outputs'][0]['script_hex']).to eq('4104a30984dcecc38d8bb47ed1362787416bf0c39ec1afb07847d72e576f3776f3aa80570d6483c2fa09dc8b6161efd03125755752318838d2635932b1c2c43e9a14ac')
+      expect(json['transactions'][0]['outputs'][0]['script_type']).to eq('pubkey')
+      expect(json['transactions'][0]['outputs'][0]['addresses'][0]).to eq('mw851HctCPZUuRCC4KktwKCJQqBz9Xwohz')
+      expect(json['transactions'][0]['amount']).to eq(5000000000)
+      expect(json['transactions'][0]['fees']).to eq(0)
+      expect(json['transactions'][0]['confirmations']).to eq(2)
+      expect(json['transactions'][0]['block_height']).to eq(6)
+      expect(json['transactions'][0]['block_hash']).to eq('000ff5c07c4fecfed17ce7af54e968656d2f568e68753100748a00ae1ed79ee9')
+      expect(json['transactions'][0]['block_time']).to eq('2014-06-07T23:39:45Z')
+      expect(json['transactions'][0]['block_branch']).to eq('main')
+    end
+  end
+
   describe "GET /addresses/<hash>/balance.<format>" do
     it "fails if not requesting json" do
       get '/addresses/mw851HctCPZUuRCC4KktwKCJQqBz9Xwohz/balance_at.xml'


### PR DESCRIPTION
For background see https://github.com/coinbase/toshi/issues/206

This patch implements a new API addresses/<hash>/transactionsfiltered

This API is useful for any application that needs to display transaction history for a given address but does not care about inputs and outputs *other* than the input address.  That is a typical scenario for various types of wallet history reports.

This API operates the same as addresses/<hash>/transactions except that it only includes inputs and outputs in the result that match the input address.   It does this by modifying the SQL query against the address_ledger_entries table to match only the input address.   So both the DB and the app work less and less data is returned to the caller.

This results in huge efficiency gains for addresses that have many transactions with multiple outputs.  For example, mining pools (including p2pool) use sendtomany to send to hundreds of addresses at once.  A receiving address may have hundreds of such transactions.  One example I saw with 200+ transactions generated a 28 Mb json file using the standard addresses/<hash>/transactions API.  That's just not acceptable when only a tiny fraction of that data is actually needed.  

In testing on testnet with the new API I saw request times go from 6 seconds down to 0.2 seconds for the same address.

This API is needed/used by a tool I have written.  http://github/dan-da/bitprices.  Which is itself intended to be used in a website I am working on: http://mybitprices.info.

Further efficiencies could be gained by accepting multiple input addresses and trimming additional fields from the output.  But this is a good start.

It is not strictly necessary to create a new API for this.  It could also be implemented as a parameter to the existing addresses/.../transactions API.  But I was trying to change as little of the existing code as possible.

I created a new test case for addresses/<hash>/transactionsfiltered.  It is the same as the test case for the original API, except it checks that the inputs array of the first transaction is empty.

This is my first time doing any ruby coding or digging into toshi. I am not married to this particular implementation.  But I do hope the toshi project will either accept the patch, or guide me how to improve it for acceptance, or implement an alternate solution to the basic problem.