### PR TITLE
Extract shared behavior module from Transaction and UnconfirmedTransaction

### DIFF
--- a/lib/toshi.rb
+++ b/lib/toshi.rb
@@ -41,6 +41,7 @@ module Toshi
     autoload :RawBlock,                   'toshi/models/raw_block'
     autoload :RawTransaction,             'toshi/models/raw_transaction'
     autoload :Transaction,                'toshi/models/transaction'
+    autoload :TransactionShared,          'toshi/models/transaction_shared'
     autoload :UnconfirmedAddress,         'toshi/models/unconfirmed_address'
     autoload :UnconfirmedInput,           'toshi/models/unconfirmed_input'
     autoload :UnconfirmedOutput,          'toshi/models/unconfirmed_output'

--- a/lib/toshi/models/transaction_shared.rb
+++ b/lib/toshi/models/transaction_shared.rb
@@ -1,0 +1,58 @@
+module Toshi
+  module Models
+    module TransactionShared
+
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      def bitcoin_tx
+        Bitcoin::P::Tx.new(raw.payload)
+      end
+
+      def inputs
+        input_class.where(hsh: hsh).order(:position)
+      end
+
+      def is_coinbase?
+        inputs_count == 1 && inputs.first.coinbase?
+      end
+
+      def outputs
+        output_class.where(hsh: hsh).order(:position)
+      end
+
+      def pool_name
+        self.class::POOL_TO_NAME_TABLE[pool] || "unknown"
+      end
+
+      def raw
+        raw_class.find(hsh: hsh)
+      end
+
+      def to_hash(options = {})
+        options[:show_block_info] ||= true
+        self.class.to_hash_collection([self], options).first
+      end
+
+      def to_json(options={})
+        to_hash(options).to_json
+      end
+
+      module ClassMethods
+        def from_hsh(hash)
+          find(hsh: hash)
+        end
+
+        # This is much faster than a count(*) on the table.
+        # See: https://wiki.postgresql.org/wiki/Slow_Counting
+        def total_count
+          Toshi.db.fetch(
+            "SELECT reltuples AS total FROM pg_class "\
+            "WHERE relname = '#{table_name}'"
+          ).first[:total].to_i
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Transaction and UnconfirmedTransaction have a lot of identical or very similar code. This PR extracts the lowest-hanging fruit into a shared module to make it more DRY.

I'm not sure if `TransactionShared` is the best name, or if `toshi/models` is the best place to put it - what do you think?