### PR TITLE
Refactoring

### DIFF
--- a/lib/toshi/blockchain_storage.rb
+++ b/lib/toshi/blockchain_storage.rb
@@ -65,7 +65,7 @@ module Toshi
         bh && bh.height
       end
       return height if height
-      b = Toshi::Models::Block.where(hsh: hash).first
+      b = Toshi::Models::Block.find(hsh: hash)
       b ? b.height : nil
     end
 
@@ -76,7 +76,7 @@ module Toshi
       if Toshi::Models::Block.where(hsh: hash).empty?
         return nil
       end
-      stored_block = Toshi::Models::RawBlock.where(hsh: hash).first
+      stored_block = Toshi::Models::RawBlock.find(hsh: hash)
       if !stored_block
         return nil
       end
@@ -96,7 +96,7 @@ module Toshi
       if !block
         return [nil, nil]
       end
-      stored_block = Toshi::Models::RawBlock.where(hsh: hash).first
+      stored_block = Toshi::Models::RawBlock.find(hsh: hash)
       if !stored_block
         return [nil, nil]
       end
@@ -113,7 +113,7 @@ module Toshi
       if Toshi::Models::Block.orphan_branch.where(hsh: hash).empty?
         return nil
       end
-      stored_block = Toshi::Models::RawBlock.where(hsh: hash).first
+      stored_block = Toshi::Models::RawBlock.find(hsh: hash)
       if !stored_block
         return nil
       end
@@ -130,7 +130,7 @@ module Toshi
 
     # Loads raw block (with unknown status: could be completely invalid)
     def raw_block_for_hash(hash)
-      stored_raw_block = Toshi::Models::RawBlock.where(hsh: hash).first
+      stored_raw_block = Toshi::Models::RawBlock.find(hsh: hash)
       if !stored_raw_block
         return nil
       end
@@ -161,7 +161,7 @@ module Toshi
         end
       end
       return work if work
-      blk = Toshi::Models::Block.where(hsh: hash).first
+      blk = Toshi::Models::Block.find(hsh: hash)
       return 0 if !blk
       blk.block_work # Not to be confused with Bitcoin::Protocol::Block#block_work which is per-block work
     end
@@ -606,7 +606,7 @@ module Toshi
 
       # Try to find in DB.
       # FIXME: This is only needed to support tests calling are_inputs_standard? directly.
-      if for_test && out = Toshi::Models::Output.where(hsh: txhash, position: out_index).first
+      if for_test && out = Toshi::Models::Output.find(hsh: txhash, position: out_index)
         txout = Bitcoin::Protocol::TxOut.new(out.amount, out.script)
         if txout
           # cache the result
@@ -634,7 +634,7 @@ module Toshi
 
       hash = Toshi::Utils.bin_to_hex_hash(binary_tx_hash)
 
-      result = if dbtx = Toshi::Models::RawTransaction.where(hsh: hash).first
+      result = if dbtx = Toshi::Models::RawTransaction.find(hsh: hash)
                  dbtx.bitcoin_tx.is_coinbase?
                elsif tx = tx_in_current_block(hash)
                  tx.is_coinbase?
@@ -649,7 +649,7 @@ module Toshi
     # Returns the height of the transaction (height of the block in which it is included)
     def height_for_tx(binary_tx_hash)
       hash = Toshi::Utils.bin_to_hex_hash(binary_tx_hash)
-      dbtx = Toshi::Models::Transaction.where(hsh: hash).first
+      dbtx = Toshi::Models::Transaction.find(hsh: hash)
       if !dbtx
         if tx = tx_in_current_block(hash)
           return 1 + self.height_for_block(@current_block.prev_block_hex)
@@ -688,7 +688,7 @@ module Toshi
 
     # Removes orphan transaction if it ends up failing validation (for reasons other than missing inputs)
     def remove_orphan_tx(hash)
-      t = Toshi::Models::Transaction.where(hsh: hash).first
+      t = Toshi::Models::Transaction.find(hsh: hash)
       if t
         t.destroy
       end

--- a/lib/toshi/blockchain_storage.rb
+++ b/lib/toshi/blockchain_storage.rb
@@ -87,8 +87,7 @@ module Toshi
     # Only if it is a valid block on main chain or side chain.
     # Orphan block is not returned.
     def valid_block_for_hash(hash)
-      block, created_at = valid_block_for_hash_with_created_at(hash)
-      block
+      valid_block_for_hash_with_created_at(hash)[0]
     end
 
     def valid_block_for_hash_with_created_at(hash)
@@ -363,6 +362,7 @@ module Toshi
 
     # This only affects the database records.
     def mark_outputs_as_spent(output_ids)
+      return unless output_ids.any?
       self.class.remove_from_utxo_set(output_ids, spent=true)
 
       # mark these spent all at once
@@ -384,6 +384,7 @@ module Toshi
 
     # This only affects the database records.
     def mark_outputs_as_unspent(output_ids, on_disconnect)
+      return unless output_ids.any?
       self.class.add_to_utxo_set(output_ids, on_disconnect)
 
       # mark these unspent all at once
@@ -400,6 +401,7 @@ module Toshi
 
     # This only affects the database records.
     def mark_outputs_as_unavailable(output_ids)
+      return unless output_ids.any?
       self.class.remove_from_utxo_set(output_ids, spent=false)
 
       # mark these as side branch outputs all at once
@@ -409,46 +411,18 @@ module Toshi
 
     # Update all the database records for outputs in a block.
     def update_outputs_on_connect_block(block)
-      spent_output_ids, unspent_output_ids = [], []
-      block.tx.each do |tx|
-        if !tx.is_coinbase?
-          tx.inputs.each do |txin|
-            if output = self.output_from_model_cache(txin.prev_out, txin.prev_out_index)
-              spent_output_ids << output.id
-            end
-          end
-        end
-        tx.outputs.each_with_index do |txout, index|
-          if output = self.output_from_model_cache(tx.binary_hash, index)
-            unspent_output_ids << output.id
-          end
-        end
-      end
+      spent_output_ids, unspent_output_ids = prev_and_next_output_ids(block)
 
-      mark_outputs_as_unspent(unspent_output_ids, on_disconnect=false) if unspent_output_ids.any?
-      mark_outputs_as_spent(spent_output_ids) if spent_output_ids.any?
+      mark_outputs_as_unspent(unspent_output_ids, on_disconnect=false)
+      mark_outputs_as_spent(spent_output_ids)
     end
 
     # Update all the database records for outputs in a block.
     def update_outputs_on_disconnect_block(block)
-      unspent_output_ids, unavailable_output_ids = [], []
-      block.tx.each do |tx|
-        if !tx.is_coinbase?
-          tx.inputs.each do |txin|
-            if output = self.output_from_model_cache(txin.prev_out, txin.prev_out_index)
-              unspent_output_ids << output.id
-            end
-          end
-        end
-        tx.outputs.each_with_index do |txout, index|
-          if output = self.output_from_model_cache(tx.binary_hash, index)
-            unavailable_output_ids << output.id
-          end
-        end
-      end
+      unspent_output_ids, unavailable_output_ids = prev_and_next_output_ids(block)
 
-      mark_outputs_as_unspent(unspent_output_ids, on_disconnect=true) if unspent_output_ids.any?
-      mark_outputs_as_unavailable(unavailable_output_ids) if unavailable_output_ids.any?
+      mark_outputs_as_unspent(unspent_output_ids, on_disconnect=true)
+      mark_outputs_as_unavailable(unavailable_output_ids)
     end
 
     # To implement BIP30, must be equivalent to (view.HaveCoins(hash) && !view.GetCoins(hash).IsPruned())
@@ -651,7 +625,7 @@ module Toshi
       hash = Toshi::Utils.bin_to_hex_hash(binary_tx_hash)
       dbtx = Toshi::Models::Transaction.find(hsh: hash)
       if !dbtx
-        if tx = tx_in_current_block(hash)
+        if tx_in_current_block(hash)
           return 1 + self.height_for_block(@current_block.prev_block_hex)
         end
         return 0xffffffff
@@ -663,7 +637,7 @@ module Toshi
 
     # move a coinbase tx to the block pool on disconnect
     def move_coinbase_tx_to_block_pool(tx_hash)
-      Toshi::Models::Transaction.where(hsh: tx_hash).update({pool: Toshi::Models::Transaction::BLOCK_POOL})
+      Toshi::Models::Transaction.where(hsh: tx_hash).update(pool: Toshi::Models::Transaction::BLOCK_POOL)
     end
 
     # Orphan blocks
@@ -679,17 +653,16 @@ module Toshi
     # Returns enumerator of orphan blocks with a given parent hash
     def orphan_blocks_with_parent(hash)
       # For now, return simply an array.
-      orphans = []
-      Toshi::Models::Block.where(prev_block: hash, branch: Toshi::Models::Block::ORPHAN_BRANCH).each do |stored_orphan|
-        orphans << self.raw_block_for_hash(stored_orphan.hsh)
+      Toshi::Models::Block.where(
+        prev_block: hash, branch: Toshi::Models::Block::ORPHAN_BRANCH
+      ).map do |stored_orphan|
+        self.raw_block_for_hash(stored_orphan.hsh)
       end
-      orphans
     end
 
     # Removes orphan transaction if it ends up failing validation (for reasons other than missing inputs)
     def remove_orphan_tx(hash)
-      t = Toshi::Models::Transaction.find(hsh: hash)
-      if t
+      if t = Toshi::Models::Transaction.find(hsh: hash)
         t.destroy
       end
     end
@@ -708,5 +681,30 @@ module Toshi
         @prevent_index_access = false
       end
     end
+
+    private
+
+
+    def prev_and_next_output_ids(block)
+      prev_ids, next_ids = [], []
+      block.tx.each do |tx|
+        tx.outputs.each_with_index do |_, index|
+          if output = self.output_from_model_cache(tx.binary_hash, index)
+            next_ids << output.id
+          end
+        end
+
+        next if tx.is_coinbase?
+
+        tx.inputs.each do |txin|
+          if output = self.output_from_model_cache(txin.prev_out, txin.prev_out_index)
+            prev_ids << output.id
+          end
+        end
+      end
+      [prev_ids, next_ids]
+    end
+
+
   end
 end

--- a/lib/toshi/bootstrap.rb
+++ b/lib/toshi/bootstrap.rb
@@ -69,7 +69,7 @@ module Toshi
 
           t = Time.now.to_f
           result = processor.process_block(block, raise_errors=true)
-          b = Toshi::Models::Block.where(hsh: block.hash).first
+          b = Toshi::Models::Block.find(hsh: block.hash)
 
           delta = (Time.now.to_f - t)
 

--- a/lib/toshi/memory_pool.rb
+++ b/lib/toshi/memory_pool.rb
@@ -27,7 +27,7 @@ module Toshi
 
     # Does the unspent output exist in the memory pool?
     def is_output_available?(tx_hash, position)
-      output = Toshi::Models::UnconfirmedOutput.where(hsh: tx_hash, position: position).first
+      output = Toshi::Models::UnconfirmedOutput.find(hsh: tx_hash, position: position)
       return false if !output || !output.transaction.in_memory_pool?
       !output.spent
     end

--- a/lib/toshi/models/address.rb
+++ b/lib/toshi/models/address.rb
@@ -65,7 +65,7 @@ module Toshi
           hash[:received] = address.total_received
           hash[:sent] = address.total_sent
 
-          unconfirmed_address = UnconfirmedAddress.where(address: address.address).first
+          unconfirmed_address = UnconfirmedAddress.find(address: address.address)
           hash[:unconfirmed_received] = unconfirmed_address ? unconfirmed_address.total_received : 0
           hash[:unconfirmed_sent] = unconfirmed_address ? unconfirmed_address.total_sent(address) : 0
           hash[:unconfirmed_balance] = unconfirmed_address ? unconfirmed_address.balance(address) : 0

--- a/lib/toshi/models/address.rb
+++ b/lib/toshi/models/address.rb
@@ -65,7 +65,7 @@ module Toshi
           hash[:received] = address.total_received
           hash[:sent] = address.total_sent
 
-          unconfirmed_address = Toshi::Models::UnconfirmedAddress.where(address: address.address).first
+          unconfirmed_address = UnconfirmedAddress.where(address: address.address).first
           hash[:unconfirmed_received] = unconfirmed_address ? unconfirmed_address.total_received : 0
           hash[:unconfirmed_sent] = unconfirmed_address ? unconfirmed_address.total_sent(address) : 0
           hash[:unconfirmed_balance] = unconfirmed_address ? unconfirmed_address.balance(address) : 0

--- a/lib/toshi/models/block.rb
+++ b/lib/toshi/models/block.rb
@@ -61,7 +61,7 @@ module Toshi
       end
 
       def bitcoin_block
-        Bitcoin::P::Block.new(RawBlock.where(hsh: hsh).first.payload)
+        Bitcoin::P::Block.new(raw.payload)
       end
 
       def branch_name
@@ -81,7 +81,7 @@ module Toshi
       end
 
       def previous
-        @previous_block ||= Block.where(hsh: prev_block).first
+        @previous_block ||= previous_blocks.first
       end
 
       def previous_blocks
@@ -89,7 +89,7 @@ module Toshi
       end
 
       def next
-        @next_block ||= Block.where(prev_block: hsh).first
+        @next_block ||= next_blocks.first
       end
 
       def next_blocks
@@ -117,7 +117,7 @@ module Toshi
       end
 
       def raw
-        Toshi::Models::RawBlock.where(hsh: hsh).first
+        RawBlock.where(hsh: hsh).first
       end
 
       # calculate additional fields not part of the protocol

--- a/lib/toshi/models/block.rb
+++ b/lib/toshi/models/block.rb
@@ -43,7 +43,7 @@ module Toshi
           locator << pointer.hsh
           depth = pointer.height - step
           break unless depth > 0
-          prev_block = Block.main_branch.where(height: depth).first
+          prev_block = Block.main_branch.find(height: depth)
           break unless prev_block
           pointer = prev_block
           step *= 2  if locator.size > 10
@@ -117,7 +117,7 @@ module Toshi
       end
 
       def raw
-        RawBlock.where(hsh: hsh).first
+        RawBlock.find(hsh: hsh)
       end
 
       # calculate additional fields not part of the protocol
@@ -145,14 +145,14 @@ module Toshi
       # <height> is this block's height. If nil, will be loaded automatically from the previous block and incremented.
       def self.create_from_block(block, height=nil, branch=Block::MAIN_BRANCH, output_cache=nil, prev_work=0)
         payload = block.payload || block.to_payload
-        RawBlock.new(hsh: block.hash, payload: Sequel.blob(payload)).save unless !RawBlock.where(hsh: block.hash).empty?
+        RawBlock.new(hsh: block.hash, payload: Sequel.blob(payload)).save if !RawBlock.find(hsh: block.hash)
 
-        height = height || ((Block.where(hsh: block.prev_block_hex).first.height rescue 0) + 1)
+        height = height || ((Block.find(hsh: block.prev_block_hex).height rescue 0) + 1)
 
         # calculate additional fields
         fields = calculate_additional_fields(block, branch)
 
-        b = Block.where(hsh: block.hash).first || b = Block.new({
+        b = Block.find(hsh: block.hash) || b = Block.new({
           hsh:                block.hash,
           prev_block:         block.prev_block_hex,
           mrkl_root:          block.mrkl_root.reverse_hth,

--- a/lib/toshi/models/input.rb
+++ b/lib/toshi/models/input.rb
@@ -3,19 +3,19 @@ module Toshi
     class Input < Sequel::Model
 
       def previous_output
-        @previous_output ||= Output.where(hsh: prev_out, position: index).first
+        @previous_output ||= Output.find(hsh: prev_out, position: index)
       end
 
       def previous_transaction
-        @previous_transaction ||= Transaction.where(hsh: prev_out).first
+        @previous_transaction ||= Transaction.find(hsh: prev_out)
       end
 
       def transaction
-        @transaction ||= Transaction.where(hsh: hsh).first
+        @transaction ||= Transaction.find(hsh: hsh)
       end
 
       def transaction_pool
-        @transaction_pool ||= Transaction.where(hsh: hsh).first.pool
+        @transaction_pool ||= Transaction.find(hsh: hsh).pool
       end
 
       def coinbase?

--- a/lib/toshi/models/output.rb
+++ b/lib/toshi/models/output.rb
@@ -14,7 +14,7 @@ module Toshi
       end
 
       def transaction
-        @transaction ||= Transaction.where(hsh: hsh).first
+        @transaction ||= Transaction.find(hsh: hsh)
       end
 
       def btc

--- a/lib/toshi/models/peer.rb
+++ b/lib/toshi/models/peer.rb
@@ -27,7 +27,7 @@ module Toshi
       attr_reader :connection
 
       def self.get(ip)
-        peer = Peer.where(ip: ip).first
+        peer = Peer.find(ip: ip)
         peer = Peer.find_or_create(ip: ip, port: Bitcoin.network[:default_port], services: 1, last_seen: Time.now, connected: false) if !peer
         return nil if peer.connected
         peer

--- a/lib/toshi/models/transaction.rb
+++ b/lib/toshi/models/transaction.rb
@@ -23,7 +23,7 @@ module Toshi
       end
 
       def bitcoin_tx
-        Bitcoin::P::Tx.new(RawTransaction.where(hsh: hsh).first.payload)
+        Bitcoin::P::Tx.new(raw.payload)
       end
 
       def confirmations
@@ -51,7 +51,7 @@ module Toshi
       end
 
       def raw
-        Toshi::Models::RawTransaction.where(hsh: hsh).first
+        RawTransaction.where(hsh: hsh).first
       end
 
       def self.from_hsh(hash)

--- a/lib/toshi/models/transaction.rb
+++ b/lib/toshi/models/transaction.rb
@@ -448,10 +448,10 @@ module Toshi
       # 4 queries per transaction array (7 if block info also requested)
       def self.to_hash_collection(transactions, options = {})
         return [] unless transactions.any?
+        transaction_ids = transactions.map(&:id)
 
         options[:show_block_info] ||= true
 
-        transaction_ids = transactions.map{|transaction| transaction.id }
 
         # gather blocks
         block_ids = []
@@ -511,7 +511,7 @@ module Toshi
           # inputs
           tx[:inputs] = []
           # NOTE: orphan tx inputs will show 0 amount from "unknown" address
-          inputs = inputs_by_hsh[transaction.hsh].sort_by{|input| input.position}
+          inputs = inputs_by_hsh[transaction.hsh].sort_by(&:position)
           inputs.each{|input|
             parsed_script = Bitcoin::Script.new(input.script)
             i = {}

--- a/lib/toshi/models/transaction.rb
+++ b/lib/toshi/models/transaction.rb
@@ -51,11 +51,11 @@ module Toshi
       end
 
       def raw
-        RawTransaction.where(hsh: hsh).first
+        RawTransaction.find(hsh: hsh)
       end
 
       def self.from_hsh(hash)
-        Transaction.where(hsh: hash).first
+        Transaction.find(hsh: hash)
       end
 
       def self.create_inputs(tx, branch, output_cache)
@@ -396,7 +396,7 @@ module Toshi
       end
 
       def self.create_from_tx(tx, pool, branch, output_cache=nil, block=nil, index=0, total_received=nil, total_sent=nil)
-        RawTransaction.new(hsh: tx.hash, payload: Sequel.blob(tx.payload)).save unless !RawTransaction.where(hsh: tx.hash).empty?
+        RawTransaction.new(hsh: tx.hash, payload: Sequel.blob(tx.payload)).save if !RawTransaction.find(hsh: tx.hash)
 
         fields = tx.additional_fields || {}
 

--- a/lib/toshi/models/transaction.rb
+++ b/lib/toshi/models/transaction.rb
@@ -488,30 +488,19 @@ module Toshi
           end
         }
 
-        inputs_by_hsh = {}
-        Input.where(id: input_ids).each{|input|
-          inputs_by_hsh[input.hsh] ||= []
-          inputs_by_hsh[input.hsh] << input
-        }
-
-        outputs_by_hsh = {}
-        Output.where(id: output_ids).each{|output|
-          outputs_by_hsh[output.hsh] ||= []
-          outputs_by_hsh[output.hsh] << output
-        }
+        inputs_by_hsh  = Input.where(id: input_ids).all.group_by(&:hsh)
+        outputs_by_hsh = Output.where(id: output_ids).all.group_by(&:hsh)
 
         # gather addresses
         addresses = {}
         address_ids = input_address_ids.values.flatten + output_address_ids.values.flatten
         Address.where(id: address_ids.uniq).each{|address| addresses[address.id] = address }
 
-        txs = []
-
         # this is a query
         max_height = Block.max_height
 
         # construct the hashes
-        transactions.each{|transaction|
+        transactions.map do |transaction|
           tx = {}
           tx[:hash] = transaction.hsh
           #tx[:nid] = transaction.bitcoin_tx.normalized_hash # TODO: add
@@ -568,9 +557,8 @@ module Toshi
             end
           end
 
-          txs << tx
-        }
-        txs
+          tx
+        end
       end
 
       def to_json(options={})

--- a/lib/toshi/models/transaction.rb
+++ b/lib/toshi/models/transaction.rb
@@ -273,7 +273,7 @@ module Toshi
         }
 
         # create address ledger entries for known addresses
-        address_index, entries = 0, []
+        _, entries = 0, []
         address_ids.each{|addr, addr_id|
           input_indexes[addr].each{|input_index|
             input = inputs[input_index]
@@ -474,7 +474,6 @@ module Toshi
 
         # gather inputs and outputs
         Toshi.db[:address_ledger_entries].where(transaction_id: transaction_ids).each{|entry|
-          transaction_id = entry[:transaction_id]
           if entry[:input_id]
             input_id = entry[:input_id]
             input_ids << input_id

--- a/lib/toshi/models/unconfirmed_address.rb
+++ b/lib/toshi/models/unconfirmed_address.rb
@@ -22,7 +22,7 @@ module Toshi
 
       # unconfirmed balance
       def balance(address_model=nil)
-        address_model ||= Address.where(address: address).first
+        address_model ||= Address.find(address: address)
         total_received - total_sent(address_model)
       end
 

--- a/lib/toshi/models/unconfirmed_input.rb
+++ b/lib/toshi/models/unconfirmed_input.rb
@@ -3,7 +3,7 @@ module Toshi
     class UnconfirmedInput < Sequel::Model
 
       def transaction
-        @transaction ||= UnconfirmedTransaction.where(hsh: hsh).first
+        @transaction ||= UnconfirmedTransaction.find(hsh: hsh)
       end
 
       def coinbase?

--- a/lib/toshi/models/unconfirmed_output.rb
+++ b/lib/toshi/models/unconfirmed_output.rb
@@ -8,11 +8,11 @@ module Toshi
                    :join_table => :unconfirmed_addresses_outputs
 
       def transaction
-        @transaction ||= UnconfirmedTransaction.where(hsh: hsh).first
+        @transaction ||= UnconfirmedTransaction.find(hsh: hsh)
       end
 
       def self.prevout(txin)
-        UnconfirmedOutput.where(hsh: txin.previous_output, position: txin.prev_out_index).first
+        UnconfirmedOutput.find(hsh: txin.previous_output, position: txin.prev_out_index)
       end
 
       def btc

--- a/lib/toshi/models/unconfirmed_transaction.rb
+++ b/lib/toshi/models/unconfirmed_transaction.rb
@@ -352,7 +352,7 @@ module Toshi
 
       def self.to_hash_collection(transactions)
         return [] unless transactions.any?
-        transaction_ids = transactions.map{|transaction| transaction.id }
+        transaction_ids = transactions.map(&:id)
 
         input_ids, output_ids = [], []
         input_amounts, input_address_ids, output_address_ids = {}, {}, {}
@@ -393,7 +393,7 @@ module Toshi
           # inputs
           tx[:inputs] = []
           if inputs_by_hsh.any?
-            inputs = inputs_by_hsh[transaction.hsh].sort_by{|input| input.position}
+            inputs = inputs_by_hsh[transaction.hsh].sort_by(&:position)
             inputs.each{|input|
               parsed_script = Bitcoin::Script.new(input.script)
               i = {}

--- a/lib/toshi/models/unconfirmed_transaction.rb
+++ b/lib/toshi/models/unconfirmed_transaction.rb
@@ -18,11 +18,11 @@ module Toshi
       end
 
       def bitcoin_tx
-        Bitcoin::P::Tx.new(UnconfirmedRawTransaction.where(hsh: hsh).first.payload)
+        Bitcoin::P::Tx.new(raw.payload)
       end
 
       def raw
-        Toshi::Models::UnconfirmedRawTransaction.where(hsh: hsh).first
+        UnconfirmedRawTransaction.where(hsh: hsh).first
       end
 
       def inputs
@@ -48,7 +48,6 @@ module Toshi
       end
 
       def previous_outputs
-        prev_outs = []
         # FIXME: I really need to knock this off and learn the Sequel gem.
         query = "select unconfirmed_outputs.id,
                         unconfirmed_outputs.hsh,
@@ -360,7 +359,6 @@ module Toshi
 
         # gather inputs and outputs
         Toshi.db[:unconfirmed_ledger_entries].where(transaction_id: transaction_ids).each{|entry|
-          transaction_id = entry[:transaction_id]
           if entry[:input_id]
             input_id = entry[:input_id]
             input_ids << input_id

--- a/lib/toshi/models/unconfirmed_transaction.rb
+++ b/lib/toshi/models/unconfirmed_transaction.rb
@@ -22,7 +22,7 @@ module Toshi
       end
 
       def raw
-        UnconfirmedRawTransaction.where(hsh: hsh).first
+        UnconfirmedRawTransaction.find(hsh: hsh)
       end
 
       def inputs
@@ -80,7 +80,7 @@ module Toshi
       end
 
       def self.from_hsh(hash)
-        UnconfirmedTransaction.where(hsh: hash).first
+        UnconfirmedTransaction.find(hsh: hash)
       end
 
       def self.create_inputs(tx)

--- a/lib/toshi/processor.rb
+++ b/lib/toshi/processor.rb
@@ -129,7 +129,7 @@ module Toshi
 
       end # synchronized
       return accepted
-    rescue ValidationError, TxValidationError => e
+    rescue ValidationError, TxValidationError
       raise if raise_errors
       accepted
     end
@@ -153,7 +153,6 @@ module Toshi
     # Returns true if transaction is valid if included in the next block.
     # See bool AcceptToMemoryPool() in bitcoind.
     def accept_to_memory_pool(tx, expect_tip=false, raise_errors=true, on_disconnect=false)
-      start_time = Time.now
       state = ValidationState.new
 
       logger.debug{ "tx: #{tx.hash} start processing" }
@@ -1067,7 +1066,6 @@ module Toshi
         # This doesn't trigger the DoS code on purpose; if it did, it would make it easier
         # for an attacker to attempt to split the network.
         raise TxValidationError, "CheckInputs() : #{tx.hash} inputs unavailable"
-        return false
       end
 
       # Get the height for the current block
@@ -1252,7 +1250,7 @@ module Toshi
         end
       end
       true
-    rescue => ex
+    rescue
       # catch parsing errors
       false
     end

--- a/lib/toshi/web/api.rb
+++ b/lib/toshi/web/api.rb
@@ -57,9 +57,9 @@ module Toshi
         if params[:hash].to_s == 'latest'
           @block = Toshi::Models::Block.head
         elsif params[:hash].to_s.size < 64 && (Integer(params[:hash]) rescue false)
-          @block = Toshi::Models::Block.where(height: params[:hash], branch: 0).first
+          @block = Toshi::Models::Block.find(height: params[:hash], branch: 0)
         else
-          @block = Toshi::Models::Block.where(hsh: params[:hash]).first
+          @block = Toshi::Models::Block.find(hsh: params[:hash])
         end
         raise NotFoundError unless @block
 
@@ -76,9 +76,9 @@ module Toshi
         if params[:hash].to_s == 'latest'
           @block = Toshi::Models::Block.head
         elsif params[:hash].to_s.size < 64 && (Integer(params[:hash]) rescue false)
-          @block = Toshi::Models::Block.where(height: params[:hash], branch: 0).first
+          @block = Toshi::Models::Block.find(height: params[:hash], branch: 0)
         else
-          @block = Toshi::Models::Block.where(hsh: params[:hash]).first
+          @block = Toshi::Models::Block.find(hsh: params[:hash])
         end
         raise NotFoundError unless @block
 
@@ -103,8 +103,8 @@ module Toshi
           return { error: 'malformed transaction' }.to_json
         end
 
-        if Toshi::Models::RawTransaction.where(hsh: ptx.hash).first ||
-            Toshi::Models::UnconfirmedRawTransaction.where(hsh: ptx.hash).first
+        if Toshi::Models::RawTransaction.find(hsh: ptx.hash) ||
+            Toshi::Models::UnconfirmedRawTransaction.find(hsh: ptx.hash)
           return { error: 'transaction already received' }.to_json
         end
 
@@ -132,8 +132,8 @@ module Toshi
       end
 
       get '/transactions/:hash.?:format?' do
-        @tx = (params[:hash].bytesize == 64 && Toshi::Models::Transaction.where(hsh: params[:hash]).first)
-        @tx ||= (params[:hash].bytesize == 64 && Toshi::Models::UnconfirmedTransaction.where(hsh: params[:hash]).first)
+        @tx = (params[:hash].bytesize == 64 && Toshi::Models::Transaction.find(hsh: params[:hash]))
+        @tx ||= (params[:hash].bytesize == 64 && Toshi::Models::UnconfirmedTransaction.find(hsh: params[:hash]))
         raise NotFoundError unless @tx
 
         case format
@@ -149,8 +149,8 @@ module Toshi
       ####
 
       get '/addresses/:address.?:format?' do
-        address = Toshi::Models::Address.where(address: params[:address]).first
-        address = Toshi::Models::UnconfirmedAddress.where(address: params[:address]).first unless address
+        address = Toshi::Models::Address.find(address: params[:address])
+        address = Toshi::Models::UnconfirmedAddress.find(address: params[:address]) unless address
         raise NotFoundError unless address
 
         case format
@@ -162,8 +162,8 @@ module Toshi
       end
 
       get '/addresses/:address/transactions.?:format?' do
-        address = Toshi::Models::Address.where(address: params[:address]).first
-        address = Toshi::Models::UnconfirmedAddress.where(address: params[:address]).first unless address
+        address = Toshi::Models::Address.find(address: params[:address])
+        address = Toshi::Models::UnconfirmedAddress.find(address: params[:address]) unless address
         raise NotFoundError unless address
 
         case format
@@ -175,7 +175,7 @@ module Toshi
       end
 
       get '/addresses/:address/unspent_outputs.?:format?' do
-        @address = Toshi::Models::Address.where(address: params[:address]).first
+        @address = Toshi::Models::Address.find(address: params[:address])
         raise NotFoundError unless @address
 
         case format
@@ -194,7 +194,7 @@ module Toshi
       end
 
       get '/addresses/:address/balance_at.?:format?' do
-        @address = Toshi::Models::Address.where(address: params[:address]).first
+        @address = Toshi::Models::Address.find(address: params[:address])
         raise NotFoundError unless @address
 
         time = params[:time]
@@ -220,11 +220,11 @@ module Toshi
       get '/search/:query.?:format?' do
         # block || tx
         if params[:query].bytesize == 64
-          if @block = Toshi::Models::Block.where(hsh: params[:query], branch: 0).first
+          if @block = Toshi::Models::Block.find(hsh: params[:query], branch: 0)
             path = 'blocks'
             hash = @block.hsh
           else
-            if @transaction = Toshi::Models::Transaction.where(hsh: params[:query]).first
+            if @transaction = Toshi::Models::Transaction.find(hsh: params[:query])
               path = 'transactions'
               hash = @transaction.hsh
             end
@@ -232,14 +232,14 @@ module Toshi
 
         # block height
         elsif /\A[0-9]+\Z/.match(params[:query])
-          if @block = Toshi::Models::Block.where(height: params[:query].to_i, branch: 0).first
+          if @block = Toshi::Models::Block.find(height: params[:query].to_i, branch: 0)
             path = 'blocks'
             hash = @block.hsh
           end
 
         # address hash
         elsif Bitcoin.valid_address?(params[:query])
-          if @address = Toshi::Models::Address.where(address: params[:query]).first
+          if @address = Toshi::Models::Address.find(address: params[:query])
             path = 'addresses'
             hash = @address.address
           end

--- a/lib/toshi/web/websocket.rb
+++ b/lib/toshi/web/websocket.rb
@@ -115,7 +115,7 @@ module Toshi
 
       # send a block to a connected websocket
       def on_channel_send_block(msg)
-        block = Toshi::Models::Block.where(hsh: msg['hash']).first
+        block = Toshi::Models::Block.find(hsh: msg['hash'])
         return unless block
         write_socket({ subscription: 'blocks', data: block.to_hash }.to_json)
       end

--- a/lib/toshi/workers/block_worker.rb
+++ b/lib/toshi/workers/block_worker.rb
@@ -9,7 +9,7 @@ module Toshi
 
       def perform(block_hash, _sender)
         if Toshi::Models::Block.main_branch.where(hsh: block_hash).empty? &&
-          raw_block = Toshi::Models::RawBlock.where(hsh: block_hash).first
+          raw_block = Toshi::Models::RawBlock.find(hsh: block_hash)
 
           begin
             result = processor.process_block(raw_block.bitcoin_block, raise_error=true)
@@ -19,7 +19,7 @@ module Toshi
           end
 
           if result
-            block = Toshi::Models::Block.where(hsh: block_hash).first
+            block = Toshi::Models::Block.find(hsh: block_hash)
             if block.previous.nil? || block.previous.is_orphan_chain?
               # if we just persisted this block as an orphan we should send another
               # 'getblocks' back to the peer who sent us this block.

--- a/lib/toshi/workers/transaction_worker.rb
+++ b/lib/toshi/workers/transaction_worker.rb
@@ -8,9 +8,9 @@ module Toshi
       sidekiq_options queue: :transactions, :retry => true
 
       def perform(tx_hash, _sender)
-        return if Toshi::Models::Transaction.where(hsh: tx_hash).first
-        return if Toshi::Models::UnconfirmedTransaction.where(hsh: tx_hash).first
-        tx = Toshi::Models::UnconfirmedRawTransaction.where(hsh: tx_hash).first
+        return if Toshi::Models::Transaction.find(hsh: tx_hash)
+        return if Toshi::Models::UnconfirmedTransaction.find(hsh: tx_hash)
+        tx = Toshi::Models::UnconfirmedRawTransaction.find(hsh: tx_hash)
         return unless tx
 
         begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with :truncation
   end
 
-  config.before do |config|
+  config.before do
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.start
     Sidekiq.redis { |c| c.flushdb }


### PR DESCRIPTION
A bunch of minor refactoring and cleanup:

1. Reduce repetition in `BlockchainStorage` by extracting a method.
2. Remove a bunch of unused or unnecessary local variables, and an unreachable statement.
3. Replace Sequel's `where...first` and/or `where...empty?` with `find` where appropriate.
4. Replace one-liner blocks with `(&:symbol)` syntax where possible.
5. Replace uses of 'each plus a temp variable' with more specific Enumerable methods where possible.