### PR TITLE
changes for deployment behind nginx subdirectory

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
 workers Integer(ENV['PUMA_WORKERS'] || 3)
 threads Integer(ENV['PUMA_MIN_THREADS']  || 1), Integer(ENV['PUMA_MAX_THREADS'] || 16)
-port ENV['PORT'] || 5000
+bind ENV['PORT'] || 'tcp://0.0.0.0:5000'
+
+

--- a/lib/toshi/web/static/js/main.js
+++ b/lib/toshi/web/static/js/main.js
@@ -1,6 +1,6 @@
 (function() {
   toshi = {
-    url: ('https:' == document.location.protocol ? 'wss://' + document.location.host : 'ws://' + document.location.host),
+    url: ('https:' == document.location.protocol ? 'wss://' + document.location.host + document.location.pathname : 'ws://' + document.location.host + document.location.pathname),
     connection: null,
     init: function() {
       this.createwebsocket();
@@ -89,7 +89,7 @@
       $('.websocket_stats.' + status).show()
     },
     getStatus: function() {
-      $.getJSON("/api/v0/toshi.json")
+      $.getJSON("api/v0/toshi.json")
         .done(function(data) {
           $('.available-peers').html(pretty_number(data.peers.available));
           $('.connected-peers').html(pretty_number(data.peers.connected));

--- a/lib/toshi/web/views/index.erb
+++ b/lib/toshi/web/views/index.erb
@@ -32,7 +32,7 @@
                 </ul>
                 <div class="clearfix tx_hash">
                   <h5>Hash</h5>
-                  <a href="/api/v0/transactions/{{hash}}"><span>{{hash}}</span></a>
+                  <a href="api/v0/transactions/{{hash}}"><span>{{hash}}</span></a>
                 </div>
               </div>
             </script>
@@ -58,7 +58,7 @@
                 </ul>
                 <div class="clearfix tx_hash">
                   <h5>Hash</h5>
-                  <a href="/api/v0/transactions/<%= tx.hsh %>"><span><%= tx.hsh %></span></a>
+                  <a href="api/v0/transactions/<%= tx.hsh %>"><span><%= tx.hsh %></span></a>
                 </div>
               </div>
               <% } %>
@@ -86,7 +86,7 @@
                 </ul>
                 <div class="clearfix block_hash">
                   <h5>Block Hash</h5>
-                  <a href="/api/v0/blocks/{{hash}}" target="_blank"><span>{{hash}}</span></a>
+                  <a href="api/v0/blocks/{{hash}}" target="_blank"><span>{{hash}}</span></a>
                 </div>
               </div>
             </script>
@@ -110,7 +110,7 @@
                 </ul>
                 <div class="clearfix block_hash">
                   <h5>Block Hash</h5>
-                  <a href="/api/v0/blocks/<%= block.hsh %>" target="_blank"><span><%= block.hsh %></span></a>
+                  <a href="api/v0/blocks/<%= block.hsh %>" target="_blank"><span><%= block.hsh %></span></a>
                 </div>
               </div>
               <% } %>
@@ -122,10 +122,10 @@
 
     <div class="col-md-4 col-lg-offset-1">
       <div class="toshi_links">
-        <iframe src="/github-btn.html?user=coinbase&repo=toshi&type=watch&count=true"
+        <iframe src="github-btn.html?user=coinbase&repo=toshi&type=watch&count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
 
-        <iframe src="/github-btn.html?user=coinbase&repo=toshi&type=fork&count=true"
+        <iframe src="github-btn.html?user=coinbase&repo=toshi&type=fork&count=true"
         allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe>
       </div>
       <div class="section_title clearfix">

--- a/lib/toshi/web/views/layout.erb
+++ b/lib/toshi/web/views/layout.erb
@@ -8,7 +8,7 @@
   <title>Toshi</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/css/admin.css">
+  <link rel="stylesheet" href="css/admin.css">
   <link rel="shortcut icon" href="images/favicon.ico">
 
   <meta property="og:title" content="Toshi - Open source Bitcoin Node">
@@ -19,7 +19,7 @@
   <meta itemprop="description" content="A full bitcoin node for building web applications.">
   <meta itemprop="image" content="https://coinbase.com/assets/toshi/og-toshi.jpg">
 
-  <link rel="shortcut icon" href="/images/favicon.ico">
+  <link rel="shortcut icon" href="images/favicon.ico">
 
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="js/plugins.js"></script>


### PR DESCRIPTION
changed some asset urls to account for toshi being served from a nginx subdirectory (e.g. www.abc.com/toshi). This is a very common pattern to avoid paying for a wildcard SSL certificate ;)

Also, changed "port" to "bind" in puma config - so that we have the flexibility to use unix sockets. 