### PR TITLE
make bind address configurable

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,3 @@
 workers Integer(ENV['PUMA_WORKERS'] || 3)
 threads Integer(ENV['PUMA_MIN_THREADS']  || 1), Integer(ENV['PUMA_MAX_THREADS'] || 16)
-port ENV['PORT'] || 5000
+bind ENV['BIND'] || 'tcp://0.0.0.0:5000'


### PR DESCRIPTION
fixes #238

* use bind instead of port in config
* use `'tcp://0.0.0.0:5000'` as default (preserves defaults)
* changes ENV variable name from `PORT` to `BIND`